### PR TITLE
Add QT High DPI Support with non-integer scales

### DIFF
--- a/RunGUI.py
+++ b/RunGUI.py
@@ -345,7 +345,8 @@ class RunWindow(QtWidgets.QMainWindow, RandomizerGUI.Ui_MainWindow):
 			self.HintButton.setText(_translate("MainWindow", "Set Hints (off)"))
 			QtGui.QGuiApplication.processEvents()
 def main():
-	os.environ["QT_ENABLE_HIGHDPI_SCALING"] = "1"
+	QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling, True)
+	QtGui.QGuiApplication.setHighDpiScaleFactorRoundingPolicy(QtCore.Qt.HighDpiScaleFactorRoundingPolicy.PassThrough)
 	app = QApplication(sys.argv)
 	form = RunWindow()
 	form.show()


### PR DESCRIPTION
This is a simple fix to change QT's High DPI mode to better handle non-integer DPI scales (I have 125% as my DPI scale)
It uses new to QT 5.14 features to not round the scale up to the nearest integer, which means the text to button scales disagree


Before:
![python_2022-10-16_16-44-38](https://user-images.githubusercontent.com/39798849/196042103-dd3ee435-4bbe-495e-b707-1eb474f97935.png)
After:
![python_2022-10-16_16-44-46](https://user-images.githubusercontent.com/39798849/196042104-d2653eb6-545d-4ada-ae71-ac7fe530c0a1.png)
